### PR TITLE
Add Hashable conformance to TTProgressHUDConfig

### DIFF
--- a/Sources/TTProgressHUD/TTProgressHUDConfig.swift
+++ b/Sources/TTProgressHUD/TTProgressHUDConfig.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public struct TTProgressHUDConfig
+public struct TTProgressHUDConfig: Hashable
 {
     var type = TTProgressHUDType.Loading
     var title:String?
@@ -101,5 +101,12 @@ public struct TTProgressHUDConfig
         self.autoHideInterval = autoHideInterval
         
         self.hapticsEnabled = hapticsEnabled
+    }
+}
+
+extension CGSize: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
     }
 }


### PR DESCRIPTION
It's always harder to add Equatable conformance to a type in another package, so I think its worth adding here. I needed it to include the config in my application state.