### PR TITLE
Fix Hashable conformance

### DIFF
--- a/Sources/TTProgressHUD/TTProgressHUDConfig.swift
+++ b/Sources/TTProgressHUD/TTProgressHUDConfig.swift
@@ -103,3 +103,10 @@ public struct TTProgressHUDConfig: Hashable {
         self.hapticsEnabled = hapticsEnabled
     }
 }
+
+extension CGSize: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
+    }
+}


### PR DESCRIPTION
The project doesn't compile since you added the `Hashable` conformance because you forgot to make `CGSize` conform to `Hashable`.